### PR TITLE
Disable set of tileHeight, calculate tileHeight according to view angle

### DIFF
--- a/demo/test/unit/test_isometric_server.gd
+++ b/demo/test/unit/test_isometric_server.gd
@@ -7,26 +7,33 @@ func after_each():
 
 func test_should_change_tile_width():
 	var expected_tile_width = 2560
-	var expected_tile_height = 128
+	var expected_tile_height = 1280
 	var expected_angle = 30
 	IsoServer.tile_width = expected_tile_width
 	assert_eq(IsoServer.tile_width, expected_tile_width, "Tile width should be " + str(expected_tile_width) + ".")
 	assert_eq(IsoServer.tile_height, expected_tile_height, "Tile height should be " + str(expected_tile_height) + ".")
 	assert_eq(IsoServer.angle, expected_angle, "Tile width should be " + str(expected_angle) + ".")
 
-func test_should_change_tile_height():
+func test_should_not_change_tile_height():
 	var expected_tile_width = 256
-	var expected_tile_height = 1280
+	var expected_tile_height = 128
 	var expected_angle = 30
-	IsoServer.tile_height = expected_tile_height
+	IsoServer.tile_height = 456651
 	assert_eq(IsoServer.tile_width, expected_tile_width, "Tile width should be " + str(expected_tile_width) + ".")
 	assert_eq(IsoServer.tile_height, expected_tile_height, "Tile height should be " + str(expected_tile_height) + ".")
 	assert_eq(IsoServer.angle, expected_angle, "Tile width should be " + str(expected_angle) + ".")
 
 func test_should_change_angle():
 	var expected_tile_width = 256
-	var expected_tile_height = 128
-	var expected_angle = 300
+	var expected_tile_height = 222
+	var expected_angle = 60
+	IsoServer.angle = expected_angle
+	assert_eq(IsoServer.tile_width, expected_tile_width, "Tile width should be " + str(expected_tile_width) + ".")
+	assert_eq(IsoServer.tile_height, expected_tile_height, "Tile height should be " + str(expected_tile_height) + ".")
+	assert_eq(IsoServer.angle, expected_angle, "Tile width should be " + str(expected_angle) + ".")
+	expected_tile_width = 256
+	expected_tile_height = 256
+	expected_angle = 90
 	IsoServer.angle = expected_angle
 	assert_eq(IsoServer.tile_width, expected_tile_width, "Tile width should be " + str(expected_tile_width) + ".")
 	assert_eq(IsoServer.tile_height, expected_tile_height, "Tile height should be " + str(expected_tile_height) + ".")

--- a/src/IsometricServer.cpp
+++ b/src/IsometricServer.cpp
@@ -2,7 +2,8 @@
 
 using namespace godot;
 
-IsometricServer::IsometricServer(): tileWidth(256), tileHeight(128), angle(30) {
+IsometricServer::IsometricServer(): tileWidth(256), angle(30) {
+    tileHeight = calculateTileHeight();
     eZ = calculateEz();
     zRatio = eZ / static_cast<float>(tileHeight);
 }
@@ -18,17 +19,12 @@ int IsometricServer::getTileWidth() const {
 
 void IsometricServer::setTileWidth(int tW) {
     tileWidth = tW;
-    //TODO calculate tileHeight
+    tileHeight = calculateTileHeight();
+    eZ = calculateEz();
 }
 
 int IsometricServer::getTileHeight() const {
     return tileHeight;
-    //TODO remove and calculate with angle and tileWidth
-}
-
-void IsometricServer::setTileHeight(int tH) {
-    tileHeight = tH;
-    //TODO remove and calculate with angle and tileWidth
 }
 
 int IsometricServer::getAngle() const {
@@ -37,8 +33,8 @@ int IsometricServer::getAngle() const {
 
 void IsometricServer::setAngle(int agl) {
     angle = agl;
+    tileHeight = calculateTileHeight();
     eZ = calculateEz();
-    //TODO calculate tileHeight
 }
 
 float IsometricServer::getEZ() const {
@@ -70,8 +66,13 @@ Vector2 IsometricServer::getScreenCoordFrom3D(const Vector3 &pos) const {
     };
 }
 
+int IsometricServer::calculateTileHeight() const {
+    return static_cast<int>(round(tileWidth * sin(deg2rad(static_cast<float>(angle)))));
+}
+
 float IsometricServer::calculateEz() const {
-    return static_cast<float>((tileHeight / sin(deg2rad(angle)) / sqrt(2)) * cos(deg2rad(angle)));
+    return static_cast<float>((tileHeight / sin(deg2rad(static_cast<float>(angle))) / sqrt(2)) * cos(deg2rad(
+            static_cast<float>(angle))));
 }
 
 bool IsometricServer::doHexagoneOverlap(const Transform2D &hex1, const Transform2D &hex2) {

--- a/src/IsometricServer.h
+++ b/src/IsometricServer.h
@@ -16,6 +16,7 @@ namespace godot {
     private:
         IsometricServer();
         ~IsometricServer() = default;
+        int calculateTileHeight() const;
         float calculateEz() const;
 
     public:
@@ -33,7 +34,6 @@ namespace godot {
         int getTileWidth() const;
         void setTileWidth(int tW);
         int getTileHeight() const;
-        void setTileHeight(int tH);
         int getAngle() const;
         void setAngle(int agl);
 

--- a/src/_IsometricServer.cpp
+++ b/src/_IsometricServer.cpp
@@ -28,9 +28,7 @@ int _IsometricServer::getTileHeight() {
     return IsometricServer::getInstance().getTileHeight();
 }
 
-void _IsometricServer::setTileHeight(int tileHeight) {
-    IsometricServer::getInstance().setTileHeight(tileHeight);
-}
+void _IsometricServer::setTileHeight(int tileHeight) {}
 
 int _IsometricServer::getAngle() {
     return IsometricServer::getInstance().getAngle();

--- a/src/helpers/MathHelper.h
+++ b/src/helpers/MathHelper.h
@@ -3,16 +3,12 @@
 
 namespace godot {
 
-    inline constexpr float deg2rad(float deg) {
-        return deg / 180.f * static_cast<float>(Math_PI);
+    inline constexpr double deg2rad(float deg) {
+        return deg / 180.0 * Math_PI;
     }
 
     inline constexpr int clamp(int value, int min, int max) {
         return value < min ? min : (value > max ? max : value);
-    }
-
-    inline constexpr int ceil(float value) {
-        return static_cast<int>(value) + 1;
     }
 
     inline constexpr real_t min(real_t val1, real_t val2) {

--- a/src/positionable/IsometricPlaceholder.cpp
+++ b/src/positionable/IsometricPlaceholder.cpp
@@ -115,7 +115,7 @@ void IsometricPlaceholder::drawPoints() {
         float eZ { IsometricServer::getInstance().eZ };
 
         int correctedZ { clamp(debugZ, 0, sizeZInt) };
-        int addedLines { ceil(zRatio * static_cast<float>(correctedZ)) };
+        int addedLines { static_cast<int>(ceil(static_cast<double>(zRatio * static_cast<real_t>(correctedZ)))) };
 
         int zDelta { debugZ - correctedZ };
         auto zDeltaFloat = static_cast<real_t>(zDelta);


### PR DESCRIPTION
This disable the ability to manually change tileHeight in IsometricServer.
It it now calculated when changing view angle and tileWidth.
It is still displayed in editor so that it is easy to know the value. 
Trying to change it will not do anything.