### PR TITLE
hotfix: set default value for placeholder type

### DIFF
--- a/demo/Scenes/examples/maps/types/ground.tres
+++ b/demo/Scenes/examples/maps/types/ground.tres
@@ -1,8 +1,0 @@
-[gd_resource type="Resource" load_steps=2 format=2]
-
-[ext_resource path="res://addons/IsometricMap/Scripts/ressource/placeholder_type.gd" type="Script" id=1]
-
-[resource]
-script = ExtResource( 1 )
-type_name = "ground"
-color = Color( 0.179688, 0.148453, 0.0547485, 1 )

--- a/demo/Scenes/examples/maps/types/water.tres
+++ b/demo/Scenes/examples/maps/types/water.tres
@@ -1,8 +1,0 @@
-[gd_resource type="Resource" load_steps=2 format=2]
-
-[ext_resource path="res://addons/IsometricMap/Scripts/ressource/placeholder_type.gd" type="Script" id=1]
-
-[resource]
-script = ExtResource( 1 )
-type_name = "water"
-color = Color( 0, 0.662745, 0.890196, 1 )

--- a/src/positionable/IsometricPlaceholder.cpp
+++ b/src/positionable/IsometricPlaceholder.cpp
@@ -18,6 +18,7 @@ void IsometricPlaceholder::_register_methods() {
 
 void IsometricPlaceholder::_init() {
     IsometricPositionable::_init();
+    setPlaceholderType(placeholderType);
 }
 
 void IsometricPlaceholder::_draw() {

--- a/src/positionable/IsometricPlaceholder.cpp
+++ b/src/positionable/IsometricPlaceholder.cpp
@@ -6,14 +6,10 @@
 
 using namespace godot;
 
-IsometricPlaceholder::IsometricPlaceholder(): typeColor(0.83, 0.83, 0.83, 1) {
-
-}
-
 void IsometricPlaceholder::_register_methods() {
     register_property("placeholder_type", &IsometricPlaceholder::setPlaceholderType,
             &IsometricPlaceholder::getPlaceholderType,
-            (Ref<PlaceholderType>) ResourceLoader::get_singleton()->load("res://addons/IsometricMap/prefab/types/default.tres"));
+                      (Ref<PlaceholderType>) nullptr);
 
     register_method("_init", &IsometricPlaceholder::_init);
     register_method("_draw", &IsometricPlaceholder::_draw);
@@ -22,7 +18,6 @@ void IsometricPlaceholder::_register_methods() {
 
 void IsometricPlaceholder::_init() {
     IsometricPositionable::_init();
-    updateColors();
 }
 
 void IsometricPlaceholder::_draw() {
@@ -148,13 +143,13 @@ void IsometricPlaceholder::drawPoints() {
 }
 
 void IsometricPlaceholder::updateColors() {
-    leftColor = PoolColorArray(Array::make(typeColor.darkened(0.25)));
-    rightColor = PoolColorArray(Array::make(typeColor.darkened(0.5)));
-    upColor = PoolColorArray(Array::make(typeColor));
-    downColor = PoolColorArray(Array::make(typeColor.darkened(0.9)));
-    sideSlopeColor = PoolColorArray(Array::make(typeColor.darkened(0.10)));
-    forwardSlopeColor = PoolColorArray(Array::make(typeColor.darkened(0.10)));
-    backwardSlopeColor = PoolColorArray(Array::make(typeColor.lightened(0.10)));
+    leftColor = PoolColorArray(Array::make(placeholderType->getColor().darkened(0.25)));
+    rightColor = PoolColorArray(Array::make(placeholderType->getColor().darkened(0.5)));
+    upColor = PoolColorArray(Array::make(placeholderType->getColor()));
+    downColor = PoolColorArray(Array::make(placeholderType->getColor().darkened(0.9)));
+    sideSlopeColor = PoolColorArray(Array::make(placeholderType->getColor().darkened(0.10)));
+    forwardSlopeColor = PoolColorArray(Array::make(placeholderType->getColor().darkened(0.10)));
+    backwardSlopeColor = PoolColorArray(Array::make(placeholderType->getColor().lightened(0.10)));
 }
 
 void IsometricPlaceholder::setMapSize(const Vector3 &size) {
@@ -175,10 +170,11 @@ Ref<PlaceholderType> IsometricPlaceholder::getPlaceholderType() const {
 }
 
 void IsometricPlaceholder::setPlaceholderType(Ref<PlaceholderType> pType) {
-    placeholderType = pType;
-    if (pType.ptr()) {
-        typeColor = placeholderType->getColor();
-        updateColors();
-        update();
+    if (pType.is_valid()) {
+        placeholderType = pType;
+    } else {
+        placeholderType = Ref<PlaceholderType>(ResourceLoader::get_singleton()->load("res://addons/IsometricMap/prefab/types/default.tres").ptr());
     }
+    updateColors();
+    update();
 }

--- a/src/positionable/IsometricPlaceholder.h
+++ b/src/positionable/IsometricPlaceholder.h
@@ -16,7 +16,6 @@ namespace godot {
 
         float tempAlpha = 0.15;
 
-        Color typeColor;
         PoolColorArray leftColor;
         PoolColorArray rightColor;
         PoolColorArray upColor;
@@ -33,7 +32,7 @@ namespace godot {
 
         void setMapSize(const Vector3 &size);
     public:
-        IsometricPlaceholder();
+        IsometricPlaceholder() = default;
         ~IsometricPlaceholder() = default;
 
         static void _register_methods();


### PR DESCRIPTION
Use of nullptr hack to get default resource without crash.
Cannot get default resource loaded at editor start time, that's why I used this nullptr hack.

This resolves #17 