### PR TITLE
Fixed add dimension before (V, B and N keys)

### DIFF
--- a/src/positionable/IsometricMap.cpp
+++ b/src/positionable/IsometricMap.cpp
@@ -20,6 +20,7 @@ void IsometricMap::_register_methods() {
     register_method("is_overlapping", &IsometricMap::isOverlapping);
     register_method("is_overlapping_aabb", &IsometricMap::isOverlappingAABB);
     register_method("has", &IsometricMap::has);
+    register_method("get_positionable_children", &IsometricMap::getPositionableChildren);
     register_method("flatten", &IsometricMap::flatten);
 
     register_method("_on_resize", &IsometricMap::_onResize);
@@ -189,6 +190,25 @@ bool IsometricMap::isOverlappingAABB(AABB aabb) {
 
 bool IsometricMap::has(IsometricPositionable *isometricPositionable) {
     return grid3D.has(isometricPositionable);
+}
+
+/**
+ * Returns positionable contained in this map.
+ *
+ * This should not be used often.
+ *
+ * @return a copy array containing positionable children.
+ */
+Array IsometricMap::getPositionableChildren() const {
+    Array positionableChildren;
+    const Array &gridArray = grid3D.getInternalArray();
+    for (int i = 0; i < gridArray.size(); i++) {
+        const Variant &element = gridArray[i];
+        if (element) {
+            positionableChildren.append(element);
+        }
+    }
+    return positionableChildren;
 }
 
 IsometricMap *IsometricMap::flatten() {

--- a/src/positionable/IsometricMap.h
+++ b/src/positionable/IsometricMap.h
@@ -39,6 +39,7 @@ namespace godot {
         bool isOverlapping(IsometricPositionable *positionable);
         bool isOverlappingAABB(AABB aabb);
         bool has(IsometricPositionable *isometricPositionable);
+        Array getPositionableChildren() const;
 
         IsometricMap *flatten();
 


### PR DESCRIPTION
Fixed V, B, N keys. There was a bug, which @PaerCode found that was causing map corruption.
The problem was that the list of child positionables was not ordered by the axis in editor, causing overlapping troubles. 