### PR TITLE
Hotfix/flatten change originals positions

### DIFF
--- a/demo/test/unit/test_isometric_map.gd
+++ b/demo/test/unit/test_isometric_map.gd
@@ -93,7 +93,10 @@ func test_assert_flatten_isometricmap():
 	inner_map.add_iso_positionable(second_in_inner)
 	var second_inner = IsometricMap.new()
 	second_inner.position3d = Vector3(5, 0, 0)
+	second_inner.size3d = Vector3(1, 1, 2)
 	var positionable = IsometricPositionable.new()
+	positionable.position3d = Vector3(0, 0, 1)
+	positionable.name = "posi"
 	second_inner.add_iso_positionable(positionable)
 	var positionable_at_root = IsometricPositionable.new()
 	positionable_at_root.position3d = Vector3(5, 1, 0)
@@ -113,4 +116,5 @@ func test_assert_flatten_isometricmap():
 	var ch = flatten_map.get_children()
 	expected_child_count = 5
 	assert_eq(flatten_map.get_children().size(), expected_child_count, "Flatten map should have " + str(expected_child_count) + "children.")
-	assert_eq(positionable.position3d, Vector3(0, 0, 0), "Original positionable's position should not have changed")
+	assert_eq(positionable.position3d, Vector3(0, 0, 1), "Original positionable's position should not have changed")
+	assert_eq(flatten_map.get_node("posi").position3d, Vector3(5, 0, 1), "Positionable should have a sum of its former position and its former parent.")

--- a/demo/test/unit/test_isometric_map.gd
+++ b/demo/test/unit/test_isometric_map.gd
@@ -113,3 +113,4 @@ func test_assert_flatten_isometricmap():
 	var ch = flatten_map.get_children()
 	expected_child_count = 5
 	assert_eq(flatten_map.get_children().size(), expected_child_count, "Flatten map should have " + str(expected_child_count) + "children.")
+	assert_eq(positionable.position3d, Vector3(0, 0, 0), "Original positionable's position should not have changed")

--- a/src/positionable/IsometricMap.cpp
+++ b/src/positionable/IsometricMap.cpp
@@ -126,17 +126,18 @@ Array IsometricMap::getFlattenPositionables(const Vector3 &offset) {
     for (int i = 0; i < children.size(); i++) {
         auto *positionable = cast_to<IsometricPositionable>(children[i]);
         if (positionable) {
-            if (auto *map = dynamic_cast<IsometricMap *>(positionable)) {
+            if (auto *map = cast_to<IsometricMap>(positionable)) {
                 const Array &innerPositionables = map->getFlattenPositionables(offset + map->getPosition3D());
                 for (int j = 0; j < innerPositionables.size(); j++) {
                     auto *innerPositionable = cast_to<IsometricPositionable>(innerPositionables[j]);
                     if (innerPositionable) {
-                        positionables.append(innerPositionable->duplicate());
+                        positionables.append(innerPositionable);
                     }
                 }
             } else {
-                positionable->setPosition3D(offset + positionable->getPosition3D());
-                positionables.append(positionable->duplicate());
+                auto *duplicatePositionable = cast_to<IsometricPositionable>(positionable->duplicate());
+                duplicatePositionable->setPosition3D(offset + positionable->getPosition3D());
+                positionables.append(duplicatePositionable);
             }
         }
     }


### PR DESCRIPTION
Flatten method had wrong behaviour. It was changing previous nodes positions.