### PR TITLE
Fixed wrong colliders position when using submaps

### DIFF
--- a/src/positionable/DynamicIsometricElement.cpp
+++ b/src/positionable/DynamicIsometricElement.cpp
@@ -10,8 +10,6 @@ void DynamicIsometricElement::_register_methods() {
     register_method("_init", &DynamicIsometricElement::_init);
     register_method("_enter_tree", &DynamicIsometricElement::_enter_tree);
     register_method("get_class", &DynamicIsometricElement::get_class);
-    register_method("has_moved", &DynamicIsometricElement::getHasMoved);
-    register_method("set_has_moved", &DynamicIsometricElement::setHasMoved);
     register_method("update_position_from_body", &DynamicIsometricElement::updatePositionFromBody);
 }
 
@@ -33,14 +31,6 @@ bool DynamicIsometricElement::getHasDefaultBody() const {
 
 void DynamicIsometricElement::setHasDefaultBody(bool b) {
     IsometricElement<DefaultKinematicBody>::setHasDefaultBody(b);
-}
-
-bool DynamicIsometricElement::getHasMoved() const {
-    return IsometricElement<DefaultKinematicBody>::getHasMoved();
-}
-
-void DynamicIsometricElement::setHasMoved(bool hm) {
-    IsometricElement<DefaultKinematicBody>::setHasMoved(hm);
 }
 
 void DynamicIsometricElement::updatePositionFromBody(PhysicsBody *physicsBody) {

--- a/src/positionable/DynamicIsometricElement.h
+++ b/src/positionable/DynamicIsometricElement.h
@@ -23,9 +23,6 @@ namespace godot {
         bool getHasDefaultBody() const override;
         void setHasDefaultBody(bool b) override;
 
-        bool getHasMoved() const override;
-        void setHasMoved(bool hm) override;
-
         void updatePositionFromBody(PhysicsBody *physicsBody) override;
     };
 

--- a/src/positionable/IsometricElement.h
+++ b/src/positionable/IsometricElement.h
@@ -36,9 +36,6 @@ namespace godot {
          */
         virtual void setHasDefaultBody(bool b);
 
-        virtual bool getHasMoved() const;
-        virtual void setHasMoved(bool hm);
-
         virtual void updatePositionFromBody(PhysicsBody *physicsBody);
 
         virtual int getSlopeType() const;
@@ -46,6 +43,9 @@ namespace godot {
         void setAABB(AABB ab) override;
         void setPosition3D(Vector3 pos) override;
         void onResize() override;
+
+        bool getHasMoved() const override;
+        void setHasMoved(bool hm) override;
     };
 
     template<class T>
@@ -82,16 +82,6 @@ namespace godot {
         if (is_inside_tree()) {
             updateDefaultBody();
         }
-    }
-
-    template<class T>
-    bool IsometricElement<T>::getHasMoved() const {
-        return hasMoved;
-    }
-
-    template<class T>
-    void IsometricElement<T>::setHasMoved(bool hm) {
-        hasMoved = hm;
     }
 
     template<class T>
@@ -140,6 +130,16 @@ namespace godot {
     void IsometricElement<T>::onResize() {
         IsometricPositionable::onResize();
         hasMoved = true;
+    }
+
+    template<class T>
+    bool IsometricElement<T>::getHasMoved() const {
+        return hasMoved;
+    }
+
+    template<class T>
+    void IsometricElement<T>::setHasMoved(bool hm) {
+        hasMoved = hm;
     }
 
     template<class T>

--- a/src/positionable/IsometricMap.cpp
+++ b/src/positionable/IsometricMap.cpp
@@ -223,3 +223,18 @@ IsometricMap *IsometricMap::flatten() {
     }
     return isometricMap;
 }
+
+void IsometricMap::setAABB(AABB ab) {
+    IsometricPositionable::setAABB(ab);
+    setHasMoved(true);
+}
+
+void IsometricMap::setHasMoved(bool hm) {
+    const Array &children = get_children();
+    for (int i = 0; i < children.size(); i++) {
+        auto *positionable = cast_to<IsometricPositionable>(children[i]);
+        if (positionable) {
+            positionable->setHasMoved(true);
+        }
+    }
+}

--- a/src/positionable/IsometricMap.h
+++ b/src/positionable/IsometricMap.h
@@ -45,6 +45,8 @@ namespace godot {
 
         void onResize() override;
         void onGridUpdated(int stair) override;
+        void setAABB(AABB ab) override;
+        void setHasMoved(bool hm) override;
     };
 }
 

--- a/src/positionable/IsometricPositionable.cpp
+++ b/src/positionable/IsometricPositionable.cpp
@@ -1,5 +1,6 @@
 #include <IsometricPositionable.h>
 #include <IsometricServer.h>
+#include "IsometricMap.h"
 
 
 using namespace godot;
@@ -22,6 +23,8 @@ void IsometricPositionable::_register_methods() {
     register_method("_on_resize", &IsometricPositionable::onResize);
     register_method("_on_grid_updated", &IsometricPositionable::onGridUpdated);
     register_method("_on_select", &IsometricPositionable::onSelect);
+    register_method("has_moved", &IsometricPositionable::getHasMoved);
+    register_method("set_has_moved", &IsometricPositionable::setHasMoved);
 
     register_property("iso_position", &IsometricPositionable::isoPosition, Vector2());
     register_property("position3d", &IsometricPositionable::setPosition3D, &IsometricPositionable::getPosition3D, Vector3());
@@ -269,4 +272,24 @@ int IsometricPositionable::getDebugZ() const {
 
 void IsometricPositionable::setDebugZ(int dZ) {
     this->debugZ = dZ;
+}
+
+Vector3 IsometricPositionable::getPositionOffset() const {
+    Vector3 offset;
+    Node *pNode = get_parent();
+    if (pNode) {
+        auto *map = cast_to<IsometricMap>(pNode);
+        if (map) {
+            offset += map->aabb.position + map->getPositionOffset();
+        }
+    }
+    return offset;
+}
+
+bool IsometricPositionable::getHasMoved() const {
+    return false;
+}
+
+void IsometricPositionable::setHasMoved(bool hm) {
+
 }

--- a/src/positionable/IsometricPositionable.h
+++ b/src/positionable/IsometricPositionable.h
@@ -51,6 +51,7 @@ namespace godot {
         virtual String get_class() const;
         Transform2D getHexagoneCoordinates() const;
         void setOutlineDrawer(Color color, real_t lineSize);
+        Vector3 getPositionOffset() const;
 
         AABB getAABB();
         virtual void setAABB(AABB ab);
@@ -70,6 +71,8 @@ namespace godot {
         virtual void onResize();
         virtual void onGridUpdated(int stair);
         virtual void onSelect(bool selected);
+        virtual bool getHasMoved() const;
+        virtual void setHasMoved(bool hm);
     };
 }
 

--- a/src/positionable/StaticIsometricElement.cpp
+++ b/src/positionable/StaticIsometricElement.cpp
@@ -75,14 +75,6 @@ void StaticIsometricElement::setHasDefaultBody(bool b) {
     IsometricElement<DefaultStaticBody>::setHasDefaultBody(b);
 }
 
-bool StaticIsometricElement::getHasMoved() const {
-    return IsometricElement<DefaultStaticBody>::getHasMoved();
-}
-
-void StaticIsometricElement::setHasMoved(bool hm) {
-    IsometricElement<DefaultStaticBody>::setHasMoved(hm);
-}
-
 void StaticIsometricElement::updatePositionFromBody(PhysicsBody *physicsBody) {
 
 }

--- a/src/positionable/StaticIsometricElement.h
+++ b/src/positionable/StaticIsometricElement.h
@@ -41,9 +41,6 @@ namespace godot {
         bool getHasDefaultBody() const override;
         void setHasDefaultBody(bool b) override;
 
-        bool getHasMoved() const override;
-        void setHasMoved(bool hm) override;
-
         void updatePositionFromBody(PhysicsBody *physicsBody) override;
     };
 }

--- a/src/positionable/physics/DefaultKinematicBody.cpp
+++ b/src/positionable/physics/DefaultKinematicBody.cpp
@@ -4,6 +4,7 @@
 #include <gen/Engine.hpp>
 #include <gen/RayShape.hpp>
 #include <helpers/MathHelper.h>
+#include <positionable/IsometricMap.h>
 
 using namespace godot;
 
@@ -27,7 +28,7 @@ void DefaultKinematicBody::_init() {
 
 void DefaultKinematicBody::_enter_tree() {
     if (parent) {
-        const Vector3 &parentPosition { parent->getPosition3D() };
+        const Vector3 &parentPosition { parent->getPosition3D() + parent->getPositionOffset() };
         const Vector3 &parentSize {parent->getSize3D()};
 
         set_global_transform({
@@ -46,7 +47,7 @@ void DefaultKinematicBody::_enter_tree() {
 void DefaultKinematicBody::_physics_process(float delta) {
     if (parent) {
         if (parent->getHasMoved()) {
-            const Vector3 &parentPosition { parent->getPosition3D() };
+            const Vector3 &parentPosition { parent->getPosition3D() + parent->getPositionOffset() };
             const Vector3 &parentSize {parent->getSize3D()};
 
             set_global_transform({

--- a/src/positionable/physics/DefaultStaticBody.cpp
+++ b/src/positionable/physics/DefaultStaticBody.cpp
@@ -20,7 +20,7 @@ void DefaultStaticBody::_enter_tree() {
 
 void DefaultStaticBody::_physics_process(float delta) {
     if (parent && parent->getHasMoved()) {
-        const Vector3 &parentPosition {parent->getPosition3D()};
+        const Vector3 &parentPosition {parent->getPosition3D() + parent->getPositionOffset()};
         set_global_transform({
             {1, 0, 0, 0, 1, 0, 0, 0, 1},
             {parentPosition.x, parentPosition.z, parentPosition.y}


### PR DESCRIPTION
There was a bug with colliders position when using submaps.
This uses of setHasMoved override from IsometricPositionable on IsometricMap to set children collider hasmoved.
Adds offset of parent in collider position.